### PR TITLE
Contrail311 fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -651,7 +651,7 @@ Contrail version must >=3.0. It is useful especially for Keystone v3.
       ...
 
 Cassandra listen interface
-------------------------------
+--------------------------
 
 .. code-block:: yaml
   
@@ -662,6 +662,21 @@ Cassandra listen interface
         port: 9042
         rpc_port: 9160
       ....
+
+OpenContrail WebUI version >= 3.1.1
+-----------------------------------
+For OpenContrail version >= 3.1.1 and Cassandra >=2.1 we should override WebUI's cassandra port from 9160 to 9042.
+
+For appropriate node at class level:
+
+.. code-block:: yaml
+    opencontrail:
+      ....
+      web:
+        database:
+          port: 9042
+      ....
+
 
 RabbitMQ HA hosts
 ------------------

--- a/metadata/service/control/analytics.yml
+++ b/metadata/service/control/analytics.yml
@@ -5,6 +5,7 @@ classes:
 parameters:
   _param:
     opencontrail_version: 2.2
+    opencontrail_api_aaa_mode: no-auth
   opencontrail:
     common:
       version: ${_param:opencontrail_version}
@@ -21,6 +22,8 @@ parameters:
     collector:
       version: ${_param:opencontrail_version}
       enabled: true
+      api:
+        aaa_mode: ${_param:opencontrail_api_aaa_mode}
       bind:
         address: ${_param:cluster_local_address}
         port: 9081

--- a/metadata/service/control/analytics.yml
+++ b/metadata/service/control/analytics.yml
@@ -5,7 +5,6 @@ classes:
 parameters:
   _param:
     opencontrail_version: 2.2
-    opencontrail_api_aaa_mode: no-auth
   opencontrail:
     common:
       version: ${_param:opencontrail_version}
@@ -22,8 +21,7 @@ parameters:
     collector:
       version: ${_param:opencontrail_version}
       enabled: true
-      api:
-        aaa_mode: ${_param:opencontrail_api_aaa_mode}
+      aaa_mode: no-auth
       bind:
         address: ${_param:cluster_local_address}
         port: 9081

--- a/metadata/service/control/cluster.yml
+++ b/metadata/service/control/cluster.yml
@@ -83,6 +83,7 @@ parameters:
     collector:
       version: ${_param:opencontrail_version}
       enabled: true
+      aaa_mode: no-auth
       bind:
         address: ${_param:cluster_local_address}
         port: 9081
@@ -143,6 +144,9 @@ parameters:
         id: 2
       - host: ${_param:cluster_node03_address}
         id: 3
+      database:
+        engine: cassandra
+        port: 9160
       identity:
         engine: keystone
         version: '2.0'

--- a/metadata/service/control/control.yml
+++ b/metadata/service/control/control.yml
@@ -124,6 +124,9 @@ parameters:
         id: 2
       - host: ${_param:cluster_node03_address}
         id: 3
+      database:
+        engine: cassandra
+        port: 9160
       identity:
         engine: keystone
         version: '2.0'

--- a/metadata/service/control/single.yml
+++ b/metadata/service/control/single.yml
@@ -74,6 +74,7 @@ parameters:
     collector:
       version: ${_param:opencontrail_version}
       enabled: true
+      aaa_mode: no-auth
       bind:
         address: ${_param:single_address}
         port: 9081
@@ -122,6 +123,9 @@ parameters:
       members:
       - host: ${_param:single_address}
         id: 1
+      database:
+        engine: cassandra
+        port: 9160      
       identity:
         engine: keystone
         version: '2.0'

--- a/opencontrail/files/3.0/config.global.js
+++ b/opencontrail/files/3.0/config.global.js
@@ -187,7 +187,7 @@ config.redis_password = '';
 /* Cassandra Server */
 config.cassandra = {};
 config.cassandra.server_ips = [{%- for member in web.members %}'{{ member.host }}'{% if not loop.last %},{% endif %}{%- endfor %}];
-config.cassandra.server_port = '9160';
+config.cassandra.server_port = '{{ web.database.port }}';
 config.cassandra.enable_edit = false;
 
 /* KUE Job Scheduler */

--- a/opencontrail/files/3.0/contrail-analytics-api.conf
+++ b/opencontrail/files/3.0/contrail-analytics-api.conf
@@ -11,7 +11,7 @@ log_level = SYS_NOTICE
 log_category = 
 log_file = /var/log/contrail/contrail-analytics-api.log
 
-aaa_mode = {{ collector.api.get('aaa_mode', 'no-auth') }}
+aaa_mode = {{ collector.get('aaa_mode', 'no-auth') }}
 
 # Time-to-live in hours of the various data stored by collector into
 # cassandra

--- a/opencontrail/files/3.0/contrail-analytics-api.conf
+++ b/opencontrail/files/3.0/contrail-analytics-api.conf
@@ -11,6 +11,8 @@ log_level = SYS_NOTICE
 log_category = 
 log_file = /var/log/contrail/contrail-analytics-api.log
 
+aaa_mode = {{ collector.api.get('aaa_mode', 'no-auth') }}
+
 # Time-to-live in hours of the various data stored by collector into
 # cassandra
 # analytics_config_audit_ttl, if not set (or set to -1), defaults to analytics_data_ttl


### PR DESCRIPTION
- WebUI cassandra port parameterization, so we can use 9042 for new installation and 9160 for old ones.
- According to https://github.com/Juniper/contrail-controller/wiki/RBAC we should use aaa_mode = no-auth so we can use WebUI 