### PR TITLE
Fixing deployment of contrail-analytics with version 3.0.

### DIFF
--- a/opencontrail/collector.sls
+++ b/opencontrail/collector.sls
@@ -76,6 +76,16 @@ opencontrail_collector_packages:
     - service: opencontrail_collector_services
 {%- endif %}
 
+/etc/contrail/supervisord_analytics_files/contrail-alarm-gen.ini:
+  file.managed:
+  - source: salt://opencontrail/files/{{ collector.version }}/collector/contrail-alarm-gen.ini
+  - require:
+    - pkg: opencontrail_collector_packages
+{%- if not grains.get('noservices', False) %}
+  - require_in:
+    - service: opencontrail_collector_services
+{%- endif %}
+
 /etc/contrail/supervisord_analytics.conf:
   file.managed:
   - source: salt://opencontrail/files/{{ collector.version }}/collector/supervisord_analytics.conf

--- a/opencontrail/files/3.0/collector/contrail-alarm-gen.ini
+++ b/opencontrail/files/3.0/collector/contrail-alarm-gen.ini
@@ -1,0 +1,13 @@
+[program:contrail-alarm-gen]
+command=/usr/bin/contrail-alarm-gen -c /etc/contrail/contrail-alarm-gen.conf
+priority=440
+autostart=true
+killasgroup=true
+stopsignal=KILL
+stdout_capture_maxbytes=1MB
+redirect_stderr=true
+stdout_logfile=/var/log/contrail/contrail-alarm-gen-%(process_num)s-stdout.log
+stderr_logfile=/var/log/contrail/contrail-alarm-gen-%(process_num)s-stderr.log
+startsecs=5
+exitcodes=0                   ; 'expected' exit codes for process (default 0,2)
+user=contrail


### PR DESCRIPTION
For some reason the configuration file needs to specified when executed by the supervisord process.