### PR TITLE
introduce kafka replication.factor

### DIFF
--- a/opencontrail/files/3.0/server.properties
+++ b/opencontrail/files/3.0/server.properties
@@ -120,3 +120,6 @@ zookeeper.connect={% for member in database.members %}{{ member.host }}:2181{% i
 # Timeout in ms for connecting to zookeeper
 log.cleanup.policy=compact
 delete.topic.enable=true
+
+default.replication.factor={% if database.members|length>1 %}2{% else %}1{% endif %}
+


### PR DESCRIPTION
Change-Id: Ic4f7178d1815e835db7fb657cb46d70bfdb2940c

The setting is configured on fuel-contrail plugin as well:
https://github.com/openstack/fuel-plugin-contrail/blame/master/deployment_scripts/puppet/modules/contrail/templates/kafka-server.properties.erb#L122

The setting is related to:
* https://issues.apache.org/jira/browse/KAFKA-691
* https://bugs.launchpad.net/juniperopenstack/+bug/1536085

Customer issue:
https://mirantis.jira.com/browse/RIL-1072