### PR TITLE
Add configuration options for Default and vDNS default forwarders

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1105,6 +1105,44 @@ Enforcing physical/logical interfaces for routers
                     virtual_network: 'virtual-network'
 
 
+Contrail DNS custom forwarders
+------------------------------
+
+By default Contrail uses the /etc/resolv.conf file to determine the upstream DNS servers.
+This can have some side-affects, like resolving internal DNS entries on you public instances.
+
+In order to overrule this default set, you can configure nameservers using pillar data.
+The formula is then responsible for configuring and generating a alternate resolv.conf file.
+
+Note: this has been patched recently in the Contrail distribution of Mirantis:
+https://github.com/Mirantis/contrail-controller/commit/ed9a25ccbcfebd7d079a93aecc5a1a7bf1265ea4
+https://github.com/Mirantis/contrail-controller/commit/94c844cf2e9bcfcd48587aec03d10b869e737ade
+
+
+To change forwarders for the default-dns option (which is handled by compute nodes):
+
+.. code-block:: yaml
+
+    compute:
+      ....
+      dns:
+        forwarders:
+        - 8.8.8.8
+        - 8.8.4.4
+      ....
+
+To change forwarders for vDNS zones (handled by control nodes):
+
+.. code-block:: yaml
+
+    control:
+      ....
+      dns:
+        forwarders:
+        - 8.8.8.8
+        - 8.8.4.4
+      ....
+
 
 Usage
 =====

--- a/opencontrail/common.sls
+++ b/opencontrail/common.sls
@@ -122,13 +122,5 @@ vm.overcommit_memory:
   - require:
     - file: /etc/contrail
 {%- endif %}
-{%- endif %}
 
-{%- if common.version == 3.0 and pillar.opencontrail.get('compute', {}).get('dns', {}).get('forwarders', pillar.opencontrail.get('control', {}).get('dns', {}).get('forwarders', False) ) %}
-/etc/contrail/resolv.conf:
-  file.managed:
-  - source: salt://opencontrail/files/{{ common.version }}/resolv.conf
-  - template: jinja
-  - require:
-    - file: /etc/contrail
 {%- endif %}

--- a/opencontrail/common.sls
+++ b/opencontrail/common.sls
@@ -123,3 +123,12 @@ vm.overcommit_memory:
     - file: /etc/contrail
 {%- endif %}
 {%- endif %}
+
+{%- if common.version == 3.0 and pillar.opencontrail.get('compute', {}).get('dns', {}).get('forwarders', pillar.opencontrail.get('control', {}).get('dns', {}).get('forwarders', False) ) %}
+/etc/contrail/resolv.conf:
+  file.managed:
+  - source: salt://opencontrail/files/{{ common.version }}/resolv.conf
+  - template: jinja
+  - require:
+    - file: /etc/contrail
+{%- endif %}

--- a/opencontrail/compute.sls
+++ b/opencontrail/compute.sls
@@ -59,6 +59,18 @@ net.ipv4.ip_local_reserved_ports:
   - require:
     - pkg: opencontrail_compute_packages
 
+{%- if compute.version == 3.0 and compute.get('dns', {}).get('forwarders', False) ) %}
+contrail_compute_resolv:
+  file.managed:
+  - name: /etc/contrail/resolv.conf
+  - source: salt://opencontrail/files/{{ compute.version }}/resolv.conf
+  - template: jinja
+  - defaults:
+      dns: {{ compute.get('dns', {})|yaml }}
+  - require:
+    - file: /etc/contrail
+{%- endif %}
+
 {%- endif %}
 
 /etc/contrail/agent_param:

--- a/opencontrail/compute.sls
+++ b/opencontrail/compute.sls
@@ -59,7 +59,7 @@ net.ipv4.ip_local_reserved_ports:
   - require:
     - pkg: opencontrail_compute_packages
 
-{%- if compute.version == 3.0 and compute.get('dns', {}).get('forwarders', False) ) %}
+{%- if compute.version == 3.0 and compute.get('dns', {}).get('forwarders', False) %}
 contrail_compute_resolv:
   file.managed:
   - name: /etc/contrail/resolv.conf

--- a/opencontrail/control.sls
+++ b/opencontrail/control.sls
@@ -64,6 +64,18 @@ opencontrail_control_doctrail:
   - source: salt://opencontrail/files/{{ control.version }}/control/contrail-rndc.conf
   - makedirs: True
 
+{%- if control.version == 3.0 and control.get('dns', {}).get('forwarders', False) ) %}
+contrail_control_resolv:
+  file.managed:
+  - name: /etc/contrail/resolv.conf
+  - source: salt://opencontrail/files/{{ control.version }}/resolv.conf
+  - template: jinja
+  - defaults:
+      dns: {{ control.get('dns', {})|yaml }}
+  - require:
+    - file: /etc/contrail
+{%- endif %}
+
 {%- if control.version >= 3.0 and grains.get('init') != 'systemd' %}
 
 /etc/contrail/supervisord_control_files/contrail-control-nodemgr.ini:

--- a/opencontrail/control.sls
+++ b/opencontrail/control.sls
@@ -64,7 +64,7 @@ opencontrail_control_doctrail:
   - source: salt://opencontrail/files/{{ control.version }}/control/contrail-rndc.conf
   - makedirs: True
 
-{%- if control.version == 3.0 and control.get('dns', {}).get('forwarders', False) ) %}
+{%- if control.version == 3.0 and control.get('dns', {}).get('forwarders', False) %}
 contrail_control_resolv:
   file.managed:
   - name: /etc/contrail/resolv.conf

--- a/opencontrail/files/3.0/contrail-dns.conf
+++ b/opencontrail/files/3.0/contrail-dns.conf
@@ -13,6 +13,12 @@
 # named_log_file=/var/log/contrail/contrail-named.log   # named log file
 # rndc_config_file=contrail-rndc.conf                   # rndc config file
 # rndc_secret=secretkey                                 # rndc secret
+# resolv_conf_file=                                     # Absolute path to file containing nameservers list
+{%- if control.get('dns', {}).get('forwarders', []) %}
+resolv_conf_file=/etc/contrail/resolv.conf
+{%- endif %}
+# /etc/resolv.conf is used as default if none specified.
+
   hostip={{ control.bind.address }} # Resolved IP of `hostname`
   {%- if control.name is defined %}
   hostname={{ control.name }}

--- a/opencontrail/files/3.0/contrail-dns.conf
+++ b/opencontrail/files/3.0/contrail-dns.conf
@@ -14,7 +14,7 @@
 # rndc_config_file=contrail-rndc.conf                   # rndc config file
 # rndc_secret=secretkey                                 # rndc secret
 # resolv_conf_file=                                     # Absolute path to file containing nameservers list
-{%- if control.get('dns', {}).get('forwarders', []) %}
+{%- if control.get('dns', {}).get('forwarders', False) %}
 resolv_conf_file=/etc/contrail/resolv.conf
 {%- endif %}
 # /etc/resolv.conf is used as default if none specified.

--- a/opencontrail/files/3.0/contrail-vrouter-agent.conf
+++ b/opencontrail/files/3.0/contrail-vrouter-agent.conf
@@ -104,6 +104,22 @@ max_control_nodes=2
 # the value provided by discovery service will be used.
 # server=10.0.0.1:53 10.0.0.2:53
 
+# Client port used by vrouter-agent while connecting to contrail-named
+# dns_client_port=
+
+# Timeout for DNS server queries in milli-seconds
+# dns_timeout=
+
+# Maximum retries for DNS server queries
+# dns_max_retries=
+
+# Absolute path for custom nameserver file for default-dns method
+# If none specified, /etc/resolv.conf will be used instead
+# resolv_conf_file =
+{%- if compute.get('dns', {}).get('forwarders', []) %}
+resolv_conf_file=/etc/contrail/resolv.conf
+{%- endif %}
+
 [HYPERVISOR]
 # Everything in this section is optional
 

--- a/opencontrail/files/3.0/contrail-vrouter-agent.conf
+++ b/opencontrail/files/3.0/contrail-vrouter-agent.conf
@@ -116,7 +116,7 @@ max_control_nodes=2
 # Absolute path for custom nameserver file for default-dns method
 # If none specified, /etc/resolv.conf will be used instead
 # resolv_conf_file =
-{%- if compute.get('dns', {}).get('forwarders', []) %}
+{%- if compute.get('dns', {}).get('forwarders', False) %}
 resolv_conf_file=/etc/contrail/resolv.conf
 {%- endif %}
 

--- a/opencontrail/files/3.0/resolv.conf
+++ b/opencontrail/files/3.0/resolv.conf
@@ -1,0 +1,19 @@
+{%- from "opencontrail/map.jinja" import control, compute with context %}
+
+# Custom resolv.conf file for contrail dns
+{%- if control.get('dns', {}).get('forwarders', []) %}
+# vDNS is handled on contrail-api nodes
+{%- set forwarders = control.dns.forwarders %}
+
+{%- elif compute.get('dns', {}).get('forwarders', []) %}
+# Default DNS is handled on the compute node
+{%- set forwarders = compute.dns.forwarders %}
+
+{%- else %}
+# No forwarders/nameservers found to configure
+{%- set forwarders = [] %}
+{%- endif %}
+
+{%- for host in forwarders %}
+nameserver {{ host }}
+{%- endfor %}

--- a/opencontrail/files/3.0/resolv.conf
+++ b/opencontrail/files/3.0/resolv.conf
@@ -1,19 +1,4 @@
-{%- from "opencontrail/map.jinja" import control, compute with context %}
 
-# Custom resolv.conf file for contrail dns
-{%- if control.get('dns', {}).get('forwarders', []) %}
-# vDNS is handled on contrail-api nodes
-{%- set forwarders = control.dns.forwarders %}
-
-{%- elif compute.get('dns', {}).get('forwarders', []) %}
-# Default DNS is handled on the compute node
-{%- set forwarders = compute.dns.forwarders %}
-
-{%- else %}
-# No forwarders/nameservers found to configure
-{%- set forwarders = [] %}
-{%- endif %}
-
-{%- for host in forwarders %}
+{%- for host in dns.get('forwarders', []) %}
 nameserver {{ host }}
 {%- endfor %}

--- a/tests/pillar/cluster3.sls
+++ b/tests/pillar/cluster3.sls
@@ -68,6 +68,10 @@ opencontrail:
     name: ntw-01
     bind:
       address: 127.0.0.1
+    dns:
+      forwarders:
+      - 8.8.8.8
+      - 8.8.4.4
     discovery:
       host: 127.0.0.1
     master:

--- a/tests/pillar/control3.sls
+++ b/tests/pillar/control3.sls
@@ -70,6 +70,10 @@ opencontrail:
     name: ntw-01
     bind:
       address: 127.0.0.1
+    dns:
+      forwarders:
+      - 8.8.8.8
+      - 8.8.4.4
     discovery:
       host: 127.0.0.1
     master:

--- a/tests/pillar/vrouter3.sls
+++ b/tests/pillar/vrouter3.sls
@@ -18,6 +18,10 @@ opencontrail:
       host: 127.0.0.1
     bind:
       address: 127.0.0.1
+    dns:
+      forwarders:
+      - 8.8.8.8
+      - 8.8.4.4
     interface:
       address: 127.0.0.1
       dev: eth0


### PR DESCRIPTION
The default forwarders are read from resolv.conf file
so basically it is just rendering a custom resolv.conf file
and configuring the location.

This is a option only in packages provided by Mirantis packaging.
And also for v3 only as far as i know.