### PR TITLE
Allow defining the ifmap server by host

### DIFF
--- a/opencontrail/files/3.0/contrail-control.conf
+++ b/opencontrail/files/3.0/contrail-control.conf
@@ -43,4 +43,6 @@
 # server_url= # Provided by discovery server, e.g. https://127.0.0.1:8443
 {%- if grains.get('virtual_subtype', None) == "Docker" %}
   server_url=https://{{ control.discovery.host }}:8443
+{%- elif control.get('ifmap', {}).get('hostname', False) %}
+  server_url=https://{{ control.ifmap.host }}:{{ control.ifmap.get('port', '8443') }}
 {%- endif %}


### PR DESCRIPTION
instead of using the discovery server for that.