### PR TITLE
Configure region_name, using opencontrail.config.identity.region var

### DIFF
--- a/opencontrail/files/3.0/contrail-api.conf
+++ b/opencontrail/files/3.0/contrail-api.conf
@@ -36,6 +36,7 @@ rabbit_server={{ config.message_queue.host }}
 rabbit_port={{ config.message_queue.port }}
 {%- if config.identity.engine == "keystone" and not config.get('k8s_enabled', False) %}
 auth=keystone
+region_name={{ config.identity.get('region', 'RegionOne') }}
 {%- endif %}
 #rabbit_port=5673{{ config.message_queue.port }}
 {%- if config.message_queue.virtual_host is defined %}

--- a/opencontrail/files/3.0/contrail-svc-monitor.conf
+++ b/opencontrail/files/3.0/contrail-svc-monitor.conf
@@ -13,7 +13,7 @@ log_file=/var/log/contrail/contrail-svc-monitor.log
 cassandra_server_list={% for member in config.database.members %}{{ member.host }}:9160 {% endfor %}
 disc_server_ip={{ config.discovery.host }}
 disc_server_port=5998
-region_name=RegionOne
+region_name={{ config.identity.get('region', 'RegionOne') }}
 log_local=1
 log_level=SYS_NOTICE
 {%- if config.message_queue.members is defined %}


### PR DESCRIPTION
Configurable option is defaulting to RegionOne, src: https://github.com/Mirantis/contrail-controller/blob/R3.2/src/config/api-server/utils.py#L84